### PR TITLE
Better Support For Credential Manifest

### DIFF
--- a/impl/test/index.test.ts
+++ b/impl/test/index.test.ts
@@ -8,67 +8,14 @@ import {
   requestChallengeJwtVerify,
 } from '../dist/index.js'
 
-const credentialManifest = [
-  {
-    locale: 'en-US',
-    issuer: {
-      id: 'did:example:123',
-      name: 'Washington State Government',
-      styles: {
-        thumbnail: {
-          uri: 'https://dol.wa.com/logo.png',
-          alt: 'Washington State Seal',
-        },
-        hero: {
-          uri: 'https://dol.wa.com/people-working.png',
-          alt: 'People working on serious things',
-        },
-        background: {
-          color: '#ff0000',
-        },
-        text: {
-          color: '#d4d400',
-        },
-      },
-    },
-    credential: {
-      schema: 'https://schema.org/EducationalOccupationalCredential',
-      display: {
-        title: {
-          text: 'Washington State Driver License',
-        },
-        subtitle: {
-          text: 'Class A, Commercial',
-        },
-        description: {
-          text:
-            'License to operate a vehicle with a gross combined weight rating (GCWR) of 26,001 or more pounds, as long as the GVWR of the vehicle(s) being towed is over 10,000 pounds.',
-        },
-        properties: [
-          {
-            label: 'Organ Donor',
-          },
-        ],
-      },
-      styles: {
-        thumbnail: {
-          uri: 'https://dol.wa.com/logo.png',
-          alt: 'Washington State Seal',
-        },
-        hero: {
-          uri: 'https://dol.wa.com/happy-people-driving.png',
-          alt: 'Happy people driving',
-        },
-        background: {
-          color: '#ff0000',
-        },
-        text: {
-          color: '#d4d400',
-        },
-      },
-    },
-  },
-]
+const verifiablePresentation = {
+  "@context": ["https://www.w3.org/2018/credentials/v1", "https://identity.foundation/presentation-exchange/submission/v1"],
+  "type": ["VerifiablePresentation", "PresentationSubmission"],
+  "presentation_submission": {},
+  "verifiableCredential": [],
+  "proof": {}
+}
+
 const presentationDefinition = {
   input_descriptors: [
     {
@@ -117,6 +64,68 @@ const presentationDefinition = {
     },
   ],
 }
+
+const credentialManifest = {
+  locale: 'en-US',
+  issuer: {
+    id: 'did:example:123',
+    name: 'Washington State Government',
+    styles: {
+      thumbnail: {
+        uri: 'https://dol.wa.com/logo.png',
+        alt: 'Washington State Seal',
+      },
+      hero: {
+        uri: 'https://dol.wa.com/people-working.png',
+        alt: 'People working on serious things',
+      },
+      background: {
+        color: '#ff0000',
+      },
+      text: {
+        color: '#d4d400',
+      },
+    },
+  },
+  credential: {
+    schema: 'https://schema.org/EducationalOccupationalCredential',
+    display: {
+      title: {
+        text: 'Washington State Driver License',
+      },
+      subtitle: {
+        text: 'Class A, Commercial',
+      },
+      description: {
+        text:
+          'License to operate a vehicle with a gross combined weight rating (GCWR) of 26,001 or more pounds, as long as the GVWR of the vehicle(s) being towed is over 10,000 pounds.',
+      },
+      properties: [
+        {
+          label: 'Organ Donor',
+        },
+      ],
+    },
+    styles: {
+      thumbnail: {
+        uri: 'https://dol.wa.com/logo.png',
+        alt: 'Washington State Seal',
+      },
+      hero: {
+        uri: 'https://dol.wa.com/happy-people-driving.png',
+        alt: 'Happy people driving',
+      },
+      background: {
+        color: '#ff0000',
+      },
+      text: {
+        color: '#d4d400',
+      },
+    },
+  },
+  presentation_definition: presentationDefinition,
+}
+
 const callbackUrl = 'https://example.com'
 
 const relyingPartySecret = new Uint8Array(32)
@@ -133,6 +142,7 @@ test('Offer Flow', async t => {
 
   const responseString = await new SignOfferResponseJWT({
     challenge: challengeString,
+    verifiable_presentation: verifiablePresentation
   })
     .setProtectedHeader({alg: 'HS256'})
     .sign(userSecret)

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -160,16 +160,17 @@ An example of an `offer` challenge token has the following properties (in additi
     "callbackUrl": "https://example.com/api/callback-url",
     "purpose": "offer",
     /* Using [Credential Manifest](https://identity.foundation/credential-manifest/) to define the available credentials */
-    "credential_manifest": [
-      {
-        "issuer": {
-          /* ... */
-        },
-        "credential": {
-          /* ... */
-        }
+    "credential_manifest": {
+      "issuer": {
+        /* ... */
+      },
+      "credential": {
+        /* ... */
+      },
+      "presentation_definition": {
+        /* ... */
       }
-    ]
+    }
   }
 }
 ```
@@ -177,6 +178,7 @@ An example of an `offer` challenge token has the following properties (in additi
 - `payload`
   - `purpose` MUST be `"offer"`
   - MUST have `credential_manifest`
+    - If the `credential_manifest` provides a `presentation_definition` the response MUST include a `verifiable_presentation`
 
 ### Callback URL
 
@@ -204,7 +206,19 @@ The response token is signed by the user and acts as a way to prove ownership of
   "payload": {
     "iss": "did:example:c276e12ec21ebfeb1f712ebc6f1",
     "aud": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    "challenge": "{{CHALLENGE TOKEN}}"
+    "challenge": "{{CHALLENGE TOKEN}}",
+    "verifiable_presentation": {
+      /* ... */
+      "type": [
+        "VerifiablePresentation",
+        "PresentationSubmission"
+      ],
+      "presentation_submission": {
+        /* Using Presentation Exchange's [Presentation Submission](https://identity.foundation/presentation-exchange/#presentation-submission) */
+        /* ... */
+      }
+      /* ... */
+    }
   }
 }
 ```
@@ -217,10 +231,25 @@ The response token is signed by the user and acts as a way to prove ownership of
     - `aud` MUST be the `iss` of the challenge token
   - MUST have `challenge`
     - `challenge` MUST be the challenge token given by the issuer
+  - MUST have `verifiable_presentation` IF the challenge token provides a `presentation_definition`
+    - This `VerifiablePresentation`  MUST be a `PresentationSubmission`
 
 #### Response
 
 In addition to the standard [Callback URL Response](#response) payload, the offer/claim flow adds `credentials`:
+
+```json
+{
+  "credentials": [
+    {
+      "type": ["VerifiableCredential" /* ... */]
+      // ...
+    }
+  ]
+}
+```
+
+**OR**
 
 ```json
 {


### PR DESCRIPTION
## Ultimate Problem
The spec currently doesn't support a credential manifest with a `presentation_definition`

## Solution
- Add support for this by supporting a `verifiable_presentation` field on the response token for the offer flow